### PR TITLE
Move logic out of storage.py

### DIFF
--- a/docker_explorer/de.py
+++ b/docker_explorer/de.py
@@ -107,7 +107,7 @@ class DockerExplorer(object):
   def AddMountCommand(self, args):
     """Adds the mount command to the argument_parser.
 
-    args:
+    Args:
       args (argument_parser): the argument parser to add the command to.
     """
     mount_parser = args.add_parser(
@@ -174,8 +174,9 @@ class DockerExplorer(object):
 
     Args:
       container_id (str): the ID of the container.
+
     Returns:
-      Container: the container's info.
+      container.Container: the container object.
     """
     return container.Container(
         self.docker_directory, container_id, docker_version=self.docker_version)
@@ -196,10 +197,11 @@ class DockerExplorer(object):
     return [self.GetContainer(cid) for cid in container_ids_list]
 
   def GetContainersList(self, only_running=False):
-    """Returns a list of container ids which were running, sorted by start date.
+    """Returns a list of Container objects, sorted by start time.
 
     Args:
       only_running (bool): Whether we return only running Containers.
+
     Returns:
       list(Container): list of Containers information objects.
     """
@@ -224,6 +226,7 @@ class DockerExplorer(object):
 
     Args:
       only_running (bool): Whether we display only running Containers.
+
     Returns:
       str: the string displaying information about running containers.
     """

--- a/docker_explorer/de.py
+++ b/docker_explorer/de.py
@@ -263,7 +263,7 @@ class DockerExplorer(object):
     Args:
       only_running (bool): Whether we display only running Containers.
     """
-    print(self.storage_object.ShowContainers(only_running=only_running))
+    print(self.GetContainersString(only_running=only_running))
 
   def ShowRepositories(self):
     """Displays information about the images in the Docker repository."""

--- a/docker_explorer/de.py
+++ b/docker_explorer/de.py
@@ -20,20 +20,13 @@ A tool to parse offline Docker installation.
 from __future__ import print_function, unicode_literals
 
 import argparse
-import codecs
 import os
-import sys
 
 from docker_explorer import errors
 from docker_explorer.lib import container
 from docker_explorer.lib import aufs
 from docker_explorer.lib import overlay
 from docker_explorer.lib import utils
-
-# This is to fix UnicodeEncodeError issues when python
-# suddenly changes the output encoding when sys.stdout is
-# piped into something else.
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 
 class DockerExplorer(object):

--- a/docker_explorer/de.py
+++ b/docker_explorer/de.py
@@ -67,6 +67,9 @@ class DockerExplorer(object):
           'hint: de.py -r /var/lib/docker').format(self.docker_directory)
       raise errors.BadStorageException(err_message)
 
+    self.containers_directory = os.path.join(
+        self.docker_directory, 'containers')
+
     if os.path.isfile(
         os.path.join(self.docker_directory, 'repositories-aufs')):
       # Handles Docker engine storage versions 1.9 and below.
@@ -169,6 +172,20 @@ class DockerExplorer(object):
     Returns:
       Namespace: the populated namespace.
     """
+<<<<<<< Updated upstream
+=======
+    container_ids_list = os.listdir(self.containers_directory)
+    if not container_ids_list:
+      print('Couldn\'t find any container configuration file (\'{0:s}\'). '
+            'Make sure the docker repository ({1:s}) is correct. '
+            'If it is correct, you might want to run this script'
+            ' with higher privileges.').format(
+                self.container_config_filename, self.docker_directory)
+    return [self.GetContainer(cid) for cid in container_ids_list]
+
+  def GetContainersList(self, only_running=False):
+    """Returns a list of container ids which were running.
+>>>>>>> Stashed changes
 
     self.docker_directory = os.path.abspath(options.docker_directory)
 
@@ -179,10 +196,47 @@ class DockerExplorer(object):
       container_id (str): the ID of the container.
       mountpoint (str): the path to the destination mount point.
     """
+<<<<<<< Updated upstream
     if self.storage_object is None:
       self.DetectStorage()
     self.storage_object.Mount(container_id, mountpoint)
 
+=======
+    container_object = self.GetContainer(container_id)
+    self.storage_object.Mount(container_object, mountpoint)
+
+  def GetContainersString(self, only_running=False):
+    """Returns a string describing the running containers.
+
+    Args:
+      only_running (bool): Whether we display only running Containers.
+    Returns:
+      str: the string displaying information about running containers.
+    """
+    result_string = ''
+    for container_object in self.GetContainersList(only_running=only_running):
+      image_id = container_object.image_id
+      if self.docker_version == 2:
+        image_id = image_id.split(':')[1]
+
+      if container_object.config_labels:
+        labels_list = ['{0:s}: {1:s}'.format(k, v) for (k, v) in
+                       container_object.config_labels.items()]
+        labels_str = ', '.join(labels_list)
+        result_string += 'Container id: {0:s} / Labels : {1:s}\n'.format(
+            container_object.container_id, labels_str)
+      else:
+        result_string += 'Container id: {0:s} / No Label\n'.format(
+            container_object.container_id)
+      result_string += '\tStart date: {0:s}\n'.format(
+          utils.FormatDatetime(container_object.start_timestamp))
+      result_string += '\tImage ID: {0:s}\n'.format(image_id)
+      result_string += '\tImage Name: {0:s}\n'.format(
+          container_object.config_image_name)
+
+    return result_string
+
+>>>>>>> Stashed changes
   def ShowContainers(self, only_running=False):
     """Displays the running containers.
 

--- a/docker_explorer/lib/aufs.py
+++ b/docker_explorer/lib/aufs.py
@@ -98,11 +98,11 @@ class AufsStorage(storage.Storage):
             return '{0:s}:{1:s}'.format(name, version)
     return 'not found'
 
-  def MakeMountCommands(self, container_id, mount_dir):
+  def MakeMountCommands(self, container_object, mount_dir):
     """Generates the required shell commands to mount a container's ID.
 
     Args:
-      container_id (str): the container ID to mount.
+      container_object (Container): the container object to mount.
       mount_dir (str): the path to the target mount point.
 
     Returns:
@@ -113,7 +113,6 @@ class AufsStorage(storage.Storage):
       print('Could not find /sbin/mount.aufs. Please install the aufs-tools '
             'package.')
 
-    container_object = self.GetContainer(container_id)
     mount_id = container_object.mount_id
 
     container_layers_filepath = os.path.join(

--- a/docker_explorer/lib/container.py
+++ b/docker_explorer/lib/container.py
@@ -87,7 +87,9 @@ class Container(object):
       self.start_timestamp = json_state.get('StartedAt', False)
     self.storage_driver = container_info_dict.get('Driver', None)
     if self.storage_driver is None:
-      raise errors.BadContainerException('TODO')
+      raise errors.BadContainerException(
+          '{0} container config file lacks Driver key'.format(
+              container_info_json_path))
     self.volumes = container_info_dict.get('Volumes', None)
 
     if docker_version == 2:

--- a/docker_explorer/lib/container.py
+++ b/docker_explorer/lib/container.py
@@ -18,6 +18,8 @@ from __future__ import print_function, unicode_literals
 
 import json
 
+from docker_explorer import errors
+
 
 class Container(object):
   """Implements methods to access information about a Docker container.
@@ -38,19 +40,29 @@ class Container(object):
       container. (Docker storage backend v1).
   """
 
-  def __init__(self, container_id, container_info_json_path):
+  def __init__(self, container_info_json_path):
     """Initializes the Container class.
 
     Args:
       container_id (str): the container ID.
       container_info_json_path (str): the path to the JSON file containing the
         container's information.
+
+    Raises:
+      errors.BadContainerException: if there was an error with parsing
+        container_info_json_path
     """
-    self.container_id = container_id
 
     with open(container_info_json_path) as container_info_json_file:
       container_info_dict = json.load(container_info_json_file)
 
+    if container_info_dict is None:
+      raise errors.BadContainerException(
+          'Could not load container configuration file {0}'.format(
+              container_info_json_path)
+      )
+
+    self.container_id = container_info_dict.get('ID', None)
     json_config = container_info_dict.get('Config', None)
     if json_config:
       self.config_image_name = json_config.get('Image', None)

--- a/docker_explorer/lib/container.py
+++ b/docker_explorer/lib/container.py
@@ -52,7 +52,15 @@ class Container(object):
       errors.BadContainerException: if there was an error with parsing
         container_info_json_path
     """
+    self.container_config_filename = 'config.v2.json'
+    if docker_version == 1:
+      self.container_config_filename = 'config.json'
 
+    self.docker_directory = docker_directory
+
+    container_info_json_path = os.path.join(
+        self.docker_directory, 'containers', container_id,
+        self.container_config_filename)
     with open(container_info_json_path) as container_info_json_file:
       container_info_dict = json.load(container_info_json_file)
 

--- a/docker_explorer/lib/container.py
+++ b/docker_explorer/lib/container.py
@@ -96,4 +96,3 @@ class Container(object):
           'mounts', container_id)
       with open(os.path.join(c_path, 'mount-id')) as mount_id_file:
         self.mount_id = mount_id_file.read()
-

--- a/docker_explorer/lib/container.py
+++ b/docker_explorer/lib/container.py
@@ -50,7 +50,7 @@ class Container(object):
       docker_version (int): (Optional) the version of the Docker storage module.
 
     Raises:
-      errors.BadContainerException: if there was an error with parsing
+      errors.BadContainerException: if there was an error when parsing
         container_info_json_path
     """
     self.container_config_filename = 'config.v2.json'

--- a/docker_explorer/lib/overlay.py
+++ b/docker_explorer/lib/overlay.py
@@ -40,18 +40,17 @@ class OverlayStorage(storage.Storage):
     return os.path.join(
         self.docker_directory, self.STORAGE_METHOD, lower.strip(), 'root')
 
-  def MakeMountCommands(self, container_id, mount_dir):
+  def MakeMountCommands(self, container_object, mount_dir):
     """Generates the required shell commands to mount a container's ID.
 
     Args:
-      container_id (str): the container ID to mount.
+      container_object (Container): the container object.
       mount_dir (str): the path to the target mount point.
 
     Returns:
       list: a list commands that needs to be run to mount the container's view
         of the file system.
     """
-    container_object = self.GetContainer(container_id)
     mount_id_path = os.path.join(
         self.docker_directory, self.STORAGE_METHOD, container_object.mount_id)
 

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Base class for a Docker Storage object."""
 
+from __future__ import print_function, unicode_literals
 
 import json
 import os
@@ -302,7 +303,7 @@ class Storage(object):
     """Returns a string representing the modification history of a container.
 
     Args:
-      container_obj (Container): the container object.
+      container (Container): the container object.
       show_empty_layers (bool): whether to display empty layers.
     Returns:
       str: the human readable history.

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -202,8 +202,8 @@ class Storage(object):
     for c in commands:
       print(c)
     print('Do you want to mount this container Id: {0:s} on {1:s} ?\n'
-          '(ie: run these commands) [Y/n]').format(
-              container_object.container_id, mount_dir)
+          '(ie: run these commands) [Y/n]'.format(
+              container_object.container_id, mount_dir))
     choice = raw_input().lower()
     if not choice or choice == 'y' or choice == 'yes':
       for c in commands:

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -122,8 +122,7 @@ class Storage(object):
     container_info_json_path = os.path.join(
         self.containers_directory, container_id, self.container_config_filename)
     if os.path.isfile(container_info_json_path):
-      container_obj = container.Container(
-          container_id, container_info_json_path)
+      container_obj = container.Container(container_info_json_path)
 
     if self.docker_version == 2:
       c_path = os.path.join(

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Base class for a Docker Storage object."""
 
-from __future__ import print_function, unicode_literals
 
 import json
 import os

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -21,7 +21,6 @@ import os
 import subprocess
 import sys
 
-from docker_explorer.lib import container
 from docker_explorer.lib import utils
 
 

--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Base class for a Docker Storage object."""
 
+from __future__ import print_function, unicode_literals
 
 import json
 import os

--- a/tests.py
+++ b/tests.py
@@ -216,7 +216,8 @@ class TestAufsStorage(StorageTestCase):
     container_id = (
         '7b02fb3e8a665a63e32b909af5babb7d6ba0b64e10003b2d9534c7d5f2af8966')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(
+        container_obj, '/mnt')
     expected_commands = [
         ('mount -t aufs -o ro,br=test_data/docker/aufs/diff/test_data/docker/'
          'aufs/diff/'
@@ -247,7 +248,8 @@ class TestAufsStorage(StorageTestCase):
         '\tsize : 0\tcreated at : 2017-01-13T22:13:54.401355\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
     self.assertEqual(
-        expected_string, self.de_object.storage_object.GetHistory(container_obj))
+        expected_string,
+        self.de_object.storage_object.GetHistory(container_obj))
 
 
 class TestOverlayStorage(StorageTestCase):
@@ -348,7 +350,8 @@ class TestOverlayStorage(StorageTestCase):
     container_id = (
         '5dc287aa80b460652a5584e80a5c8c1233b0c0691972d75424cf5250b917600a')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(
+        container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
         '"test_data/docker/overlay/a94d714512251b0d8a9bfaacb832e0c6cb70f71cb71'
@@ -371,7 +374,9 @@ class TestOverlayStorage(StorageTestCase):
         '5b0d59026729b68570d99bc4f3f7c31a2e4f2a5736435641565d93e7c25bd2c3\n'
         '\tsize : 0\tcreated at : 2018-01-24T04:29:35.590938\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
-    self.assertEqual(expected_string, self.de_object.storage_object.GetHistory(container_obj))
+    self.assertEqual(
+        expected_string,
+        self.de_object.storage_object.GetHistory(container_obj))
 
 
 class TestOverlay2Storage(StorageTestCase):
@@ -473,7 +478,8 @@ class TestOverlay2Storage(StorageTestCase):
     container_id = (
         '8e8b7f23eb7cbd4dfe7e91646ddd0e0f524218e25d50113559f078dfb2690206')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(
+        container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
         '"test_data/docker/overlay2/l/OTFSLJCXWCECIG6FVNGRTWUZ7D:'
@@ -498,7 +504,9 @@ class TestOverlay2Storage(StorageTestCase):
         '8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7\n'
         '\tsize : 0\tcreated at : 2018-04-05T10:41:28.876407\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
-    self.assertEqual(expected_string, self.de_object.storage_object.GetHistory(container_obj))
+    self.assertEqual(
+        expected_string,
+        self.de_object.storage_object.GetHistory(container_obj))
 
 del StorageTestCase
 

--- a/tests.py
+++ b/tests.py
@@ -28,11 +28,10 @@ from docker_explorer import errors
 
 from docker_explorer.lib import aufs
 from docker_explorer.lib import overlay
-from docker_explorer.lib import storage
 from docker_explorer.lib import utils
 
 
-# pylint: disable=protected-accesso
+# pylint: disable=protected-access
 
 class UtilsTests(unittest.TestCase):
   """Tests Utils methods."""

--- a/tests.py
+++ b/tests.py
@@ -75,7 +75,8 @@ class TestDEMain(unittest.TestCase):
     self.assertEqual(expected_docker_root, options.docker_directory)
 
   def testDetectStorageFail(self):
-    """Tests that the DockerExplorer.DetectStorage function fails."""
+    """Tests that the DockerExplorer.DetectStorage function fails on
+    Docker directory."""
     de_object = de.DockerExplorer()
     de_object.docker_directory = 'this_dir_shouldnt_exist'
 

--- a/tests.py
+++ b/tests.py
@@ -28,10 +28,11 @@ from docker_explorer import errors
 
 from docker_explorer.lib import aufs
 from docker_explorer.lib import overlay
+from docker_explorer.lib import storage
 from docker_explorer.lib import utils
 
 
-# pylint: disable=protected-access
+# pylint: disable=protected-accesso
 
 class UtilsTests(unittest.TestCase):
   """Tests Utils methods."""

--- a/tests.py
+++ b/tests.py
@@ -108,7 +108,6 @@ class StorageTestCase(unittest.TestCase):
       tar.close()
     cls.de_object = de.DockerExplorer()
     cls.de_object._SetDockerDirectory(docker_directory_path)
-    cls.storage = cls.de_object.storage_object
 
     cls.driver_class = driver_class
 
@@ -154,7 +153,7 @@ class TestAufsStorage(StorageTestCase):
     container_id = (
         '7b02fb3e8a665a63e32b909af5babb7d6ba0b64e10003b2d9534c7d5f2af8966')
     container_obj = self.de_object.GetContainer(container_id)
-    layers = self.storage.GetOrderedLayers(container_obj)
+    layers = self.de_object.storage_object.GetOrderedLayers(container_obj)
     self.assertEqual(1, len(layers))
     self.assertEqual(
         'sha256:'
@@ -189,7 +188,7 @@ class TestAufsStorage(StorageTestCase):
 
   def testGetLayerInfo(self):
     """Tests the Storage.GetLayerInfo function on a AUFS storage."""
-    layer_info = self.storage.GetLayerInfo(
+    layer_info = self.de_object.storage_object.GetLayerInfo(
         'sha256:'
         '7968321274dc6b6171697c33df7815310468e694ac5be0ec03ff053bb135e768')
     self.assertEqual('2017-01-13T22:13:54.401355854Z', layer_info['created'])
@@ -198,7 +197,7 @@ class TestAufsStorage(StorageTestCase):
 
   def testShowRepositories(self):
     """Tests the Storage.ShowRepositories function on a AUFS storage."""
-    result_string = self.storage.ShowRepositories()
+    result_string = self.de_object.storage_object.ShowRepositories()
     expected_string = (
         'Listing repositories from file '
         'test_data/docker/image/aufs/repositories.json{\n'
@@ -217,7 +216,7 @@ class TestAufsStorage(StorageTestCase):
     container_id = (
         '7b02fb3e8a665a63e32b909af5babb7d6ba0b64e10003b2d9534c7d5f2af8966')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.storage.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
     expected_commands = [
         ('mount -t aufs -o ro,br=test_data/docker/aufs/diff/test_data/docker/'
          'aufs/diff/'
@@ -248,7 +247,7 @@ class TestAufsStorage(StorageTestCase):
         '\tsize : 0\tcreated at : 2017-01-13T22:13:54.401355\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
     self.assertEqual(
-        expected_string, self.storage.GetHistory(container_obj))
+        expected_string, self.de_object.storage_object.GetHistory(container_obj))
 
 
 class TestOverlayStorage(StorageTestCase):
@@ -281,7 +280,7 @@ class TestOverlayStorage(StorageTestCase):
     container_id = (
         '5dc287aa80b460652a5584e80a5c8c1233b0c0691972d75424cf5250b917600a')
     container_obj = self.de_object.GetContainer(container_id)
-    layers = self.storage.GetOrderedLayers(container_obj)
+    layers = self.de_object.storage_object.GetOrderedLayers(container_obj)
     self.assertEqual(1, len(layers))
     self.assertEqual(
         'sha256:'
@@ -317,7 +316,7 @@ class TestOverlayStorage(StorageTestCase):
 
   def testGetLayerInfo(self):
     """Tests the Storage.GetLayerInfo function on a Overlay storage."""
-    layer_info = self.storage.GetLayerInfo(
+    layer_info = self.de_object.storage_object.GetLayerInfo(
         'sha256:'
         '5b0d59026729b68570d99bc4f3f7c31a2e4f2a5736435641565d93e7c25bd2c3')
     self.assertEqual('2018-01-24T04:29:35.590938514Z', layer_info['created'])
@@ -326,7 +325,7 @@ class TestOverlayStorage(StorageTestCase):
 
   def testShowRepositories(self):
     """Tests the Storage.ShowRepositories function on a Overlay storage."""
-    result_string = self.storage.ShowRepositories()
+    result_string = self.de_object.storage_object.ShowRepositories()
     self.maxDiff = None
     expected_string = (
         'Listing repositories from file '
@@ -349,7 +348,7 @@ class TestOverlayStorage(StorageTestCase):
     container_id = (
         '5dc287aa80b460652a5584e80a5c8c1233b0c0691972d75424cf5250b917600a')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.storage.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
         '"test_data/docker/overlay/a94d714512251b0d8a9bfaacb832e0c6cb70f71cb71'
@@ -372,7 +371,7 @@ class TestOverlayStorage(StorageTestCase):
         '5b0d59026729b68570d99bc4f3f7c31a2e4f2a5736435641565d93e7c25bd2c3\n'
         '\tsize : 0\tcreated at : 2018-01-24T04:29:35.590938\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
-    self.assertEqual(expected_string, self.storage.GetHistory(container_obj))
+    self.assertEqual(expected_string, self.de_object.storage_object.GetHistory(container_obj))
 
 
 class TestOverlay2Storage(StorageTestCase):
@@ -405,7 +404,7 @@ class TestOverlay2Storage(StorageTestCase):
     container_id = (
         '8e8b7f23eb7cbd4dfe7e91646ddd0e0f524218e25d50113559f078dfb2690206')
     container_obj = self.de_object.GetContainer(container_id)
-    layers = self.storage.GetOrderedLayers(container_obj)
+    layers = self.de_object.storage_object.GetOrderedLayers(container_obj)
     self.assertEqual(1, len(layers))
     self.assertEqual(
         'sha256:'
@@ -441,7 +440,7 @@ class TestOverlay2Storage(StorageTestCase):
 
   def testGetLayerInfo(self):
     """Tests the Storage.GetLayerInfo function on a Overlay2 storage."""
-    layer_info = self.storage.GetLayerInfo(
+    layer_info = self.de_object.storage_object.GetLayerInfo(
         'sha256:'
         '8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7')
     self.assertEqual('2018-04-05T10:41:28.876407948Z', layer_info['created'])
@@ -450,7 +449,7 @@ class TestOverlay2Storage(StorageTestCase):
 
   def testShowRepositories(self):
     """Tests the Storage.ShowRepositories function on a Overlay2 storage."""
-    result_string = self.storage.ShowRepositories()
+    result_string = self.de_object.storage_object.ShowRepositories()
     self.maxDiff = None
     expected_string = (
         'Listing repositories from file '
@@ -474,7 +473,7 @@ class TestOverlay2Storage(StorageTestCase):
     container_id = (
         '8e8b7f23eb7cbd4dfe7e91646ddd0e0f524218e25d50113559f078dfb2690206')
     container_obj = self.de_object.GetContainer(container_id)
-    commands = self.storage.MakeMountCommands(container_obj, '/mnt')
+    commands = self.de_object.storage_object.MakeMountCommands(container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
         '"test_data/docker/overlay2/l/OTFSLJCXWCECIG6FVNGRTWUZ7D:'
@@ -499,11 +498,9 @@ class TestOverlay2Storage(StorageTestCase):
         '8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7\n'
         '\tsize : 0\tcreated at : 2018-04-05T10:41:28.876407\t'
         'with command : /bin/sh -c #(nop)  CMD ["sh"]')
-    self.assertEqual(expected_string, self.storage.GetHistory(container_obj))
+    self.assertEqual(expected_string, self.de_object.storage_object.GetHistory(container_obj))
 
 del StorageTestCase
-
-del(StorageTestCase)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -90,7 +90,7 @@ class TestDEMain(unittest.TestCase):
 
 
 class StorageTestCase(unittest.TestCase):
-  """ lol """
+  """Base class for tests of different Storage implementations."""
 
   @classmethod
   def tearDownClass(cls):

--- a/tests.py
+++ b/tests.py
@@ -31,7 +31,7 @@ from docker_explorer.lib import overlay
 from docker_explorer.lib import utils
 
 
-# pylint: disable=protected-access
+# pylint: disable=protected-accesso
 
 class UtilsTests(unittest.TestCase):
   """Tests Utils methods."""

--- a/tests.py
+++ b/tests.py
@@ -76,7 +76,7 @@ class TestDEMain(unittest.TestCase):
 
   def testDetectStorageFail(self):
     """Tests that the DockerExplorer.DetectStorage function fails on
-    Docker directory."""
+    non-existing Docker directory."""
     de_object = de.DockerExplorer()
     de_object.docker_directory = 'this_dir_shouldnt_exist'
 

--- a/tests.py
+++ b/tests.py
@@ -31,7 +31,7 @@ from docker_explorer.lib import overlay
 from docker_explorer.lib import utils
 
 
-# pylint: disable=protected-accesso
+# pylint: disable=protected-access
 
 class UtilsTests(unittest.TestCase):
   """Tests Utils methods."""


### PR DESCRIPTION
Couple things happening here

- Get rid of useless unicode stuff
- Move methods that search for containers out of the Storage object and back to the DockerExplorer (GetContainer, GetAllContainers, etc) because this is independent of the storage Driver.
- Have most methods use Container object as argument (instead of container ID string)
- Factor some common code in tests.py, and reflect previous changes