### PR TITLE
Make tests more predictible

### DIFF
--- a/docker_explorer/de.py
+++ b/docker_explorer/de.py
@@ -259,7 +259,7 @@ class DockerExplorer(object):
         if os.path.isfile(repositories_file_path):
           repositories.append(repositories_file_path)
 
-    for repositories_file_path in repositories:
+    for repositories_file_path in sorted(repositories):
       result_string += (
           'Listing repositories from file {0:s}\n'.format(
               repositories_file_path))

--- a/tests.py
+++ b/tests.py
@@ -464,6 +464,11 @@ class TestOverlay2Storage(DockerTestCase):
     self.maxDiff = None
     expected_string = (
         'Listing repositories from file '
+        'test_data/docker/image/overlay/repositories.json\n'
+        '{\n'
+        '    "Repositories": {}\n'
+        '}\n'
+        'Listing repositories from file '
         'test_data/docker/image/overlay2/repositories.json\n{\n'
         '    "Repositories": {\n'
         '        "busybox": {\n'
@@ -475,11 +480,6 @@ class TestOverlay2Storage(DockerTestCase):
         'c7"\n'
         '        }\n'
         '    }\n'
-        '}\n'
-        'Listing repositories from file '
-        'test_data/docker/image/overlay/repositories.json\n'
-        '{\n'
-        '    "Repositories": {}\n'
         '}\n'
 
     )


### PR DESCRIPTION
To make tests more robusts, we sort the list of return repositories.