### PR TITLE
Fix overlay

### DIFF
--- a/docker_explorer/lib/storage.py
+++ b/docker_explorer/lib/storage.py
@@ -200,12 +200,10 @@ class OverlayStorage(BaseStorage):
     with open(os.path.join(mount_id_path, self.LOWERDIR_NAME)) as lower_fd:
       lower_dir = self._BuildLowerLayers(lower_fd.read().strip())
     upper_dir = os.path.join(mount_id_path, self.UPPERDIR_NAME)
-    work_dir = os.path.join(mount_id_path, 'work')
 
     cmd_pattern = (
-        'mount -t overlay overlay -o ro,lowerdir=\"{0:s}\":"{1:s}\",'
-        'workdir="{2:s}\" \"{3:s}\"')
-    cmd = cmd_pattern.format(lower_dir, upper_dir, work_dir, mount_dir)
+        'mount -t overlay overlay -o ro,lowerdir="{0:s}:{1:s}" "{2:s}"')
+    cmd = cmd_pattern.format(upper_dir, lower_dir, mount_dir)
     return [cmd]
 
 

--- a/tests.py
+++ b/tests.py
@@ -381,12 +381,11 @@ class TestOverlayStorage(DockerTestCase):
         container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
-        '"test_data/docker/overlay/a94d714512251b0d8a9bfaacb832e0c6cb70f71cb71'
-        '976cca7a528a429336aae/root":'
         '"test_data/docker/overlay/974e2b994f9db74e1ddd6fc546843bc65920e786612'
-        'a388f25685acf84b3fed1/upper",'
-        'workdir="test_data/docker/overlay/974e2b994f9db74e1ddd6fc546843bc6592'
-        '0e786612a388f25685acf84b3fed1/work" "/mnt"')]
+        'a388f25685acf84b3fed1/upper:'
+        'test_data/docker/overlay/a94d714512251b0d8a9bfaacb832e0c6cb70f71cb71'
+        '976cca7a528a429336aae/root" '
+        '"/mnt"')]
     self.assertEqual(expected_commands, commands)
 
   def testGetHistory(self):
@@ -537,13 +536,10 @@ class TestOverlay2Storage(DockerTestCase):
         container_obj, '/mnt')
     expected_commands = [(
         'mount -t overlay overlay -o ro,lowerdir='
-        '"test_data/docker/overlay2/l/OTFSLJCXWCECIG6FVNGRTWUZ7D:'
-        'test_data/docker/overlay2/l/CH5A7XWSBP2DUPV7V47B7DOOGY":'
         '"test_data/docker/overlay2/'
-        '92fd3b3e7d6101bb701743c9518c45b0d036b898c8a3d7cae84e1a06e6829b53/diff"'
-        ',workdir="test_data/docker/overlay2/'
-        '92fd3b3e7d6101bb701743c9518c45b0d036b898c8a3d7cae84e1a06e6829b53/work"'
-        ' "/mnt"'
+        '92fd3b3e7d6101bb701743c9518c45b0d036b898c8a3d7cae84e1a06e6829b53/diff:'
+        'test_data/docker/overlay2/l/OTFSLJCXWCECIG6FVNGRTWUZ7D:'
+        'test_data/docker/overlay2/l/CH5A7XWSBP2DUPV7V47B7DOOGY" "/mnt"'
         )]
     self.assertEqual(expected_commands, commands)
 


### PR DESCRIPTION
We drop the work dir (as we never need to update the container's FS), and also correctly put the latest 'upper' dir on the left of the lowerdir stack