### PR TITLE
Move listing containers out of DockerExplorer class

### DIFF
--- a/docker_explorer/container.py
+++ b/docker_explorer/container.py
@@ -32,6 +32,33 @@ except NameError:
   pass
 
 
+def GetAllContainersIDs(docker_root_directory):
+  """Gets a list of containers IDs.
+
+   Args:
+     docker_root_directory(str): the path to the Docker root directory.
+       ie: '/var/lib/docker'.
+
+   Returns:
+     list(str): the list of containers ID.
+
+   Raises:
+     errors.BadStorageException: If required files or directories are not found
+       in the provided Docker directory.
+  """
+  if not os.path.isdir(docker_root_directory):
+    raise errors.BadStorageException(
+        'Provided path is not a directory "{0}"'.format(docker_root_directory))
+  containers_directory = os.path.join(docker_root_directory, 'containers')
+
+  if not os.path.isdir(containers_directory):
+    raise errors.BadStorageException(
+        'Containers directory {0} does not exist'.format(containers_directory))
+  container_ids_list = os.listdir(containers_directory)
+
+  return container_ids_list
+
+
 class Container(object):
   """Implements methods to access information about a Docker container.
 

--- a/tools/de.py
+++ b/tools/de.py
@@ -192,17 +192,12 @@ class DockerExplorer(object):
       errors.BadStorageException: If required files or directories are not found
         in the provided Docker directory.
     """
-    if not os.path.isdir(self.containers_directory):
-      raise errors.BadStorageException(
-          'Containers directory {0} does not exist'.format(
-              self.containers_directory))
-    container_ids_list = os.listdir(self.containers_directory)
+    container_ids_list = container.GetAllContainersIDs(self.docker_directory)
     if not container_ids_list:
-      print('Could not find container directory in {0:s}.\n'
-            'Make sure the docker directory ({1:s}) is correct.\n'
+      print('Could not find any containers.\n'
+            'Make sure the docker directory ({0:s}) is correct.\n'
             'If it is correct, you might want to run this script'
-            ' with higher privileges.'.format(
-                self.containers_directory, self.docker_directory))
+            ' with higher privileges.'.format(self.docker_directory))
     return [self.GetContainer(cid) for cid in container_ids_list]
 
   def GetContainersList(self, only_running=False):


### PR DESCRIPTION
This is the first step to remove as much "real" code from tools/de.py as possible, and have everything useful part of the module